### PR TITLE
Add Deepspeech create model function and call it on Express server startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ pids
 .env.test
 
 # project specific ignores
+# language model files
+src/deepspeech/model/*
+!src/deepspeech/model/README.md

--- a/server.js
+++ b/server.js
@@ -3,6 +3,20 @@ const express = require('express');
 const path = require('path');
 const app = express();
 const port = process.env.PORT || 8080;
+const { createModel } = require('./src/deepspeech/createModel');
+
+const modelDirectory = './src/deepspeech/model';
+
+const modelOptions = {
+  // The beam width used by the decoder. A larger beam width generates better results at the cost of decoding time.
+  BEAM_WIDTH: 1024,
+  // The alpha hyperparameter of the CTC decoder. Language Model weight.
+  LM_ALPHA: 0.75,
+  // The beta hyperparameter of the CTC decoder. Word insertion weight.
+  LM_BETA: 1.85,
+};
+
+const model = createModel(modelDirectory, modelOptions);
 
 if (process.env.NODE_ENV === 'production') {
   // Serve any static files

--- a/src/deepspeech/createModel.js
+++ b/src/deepspeech/createModel.js
@@ -1,0 +1,20 @@
+const DeepSpeech = require('deepspeech');
+
+function createModel(modelDirectory, modelOptions) {
+  const modelPath = modelDirectory + '/output_graph.pbmm';
+  const modelBinaryPath = modelDirectory + '/lm.binary';
+  const triePath = modelDirectory + '/trie';
+  const model = new DeepSpeech.Model(modelPath, modelOptions.BEAM_WIDTH);
+
+  // Enable decoding using beam scoring with a KenLM language model.
+  model.enableDecoderWithLM(
+    modelBinaryPath,
+    triePath,
+    modelOptions.LM_ALPHA,
+    modelOptions.LM_BETA
+  );
+
+  return model;
+}
+
+exports.createModel = createModel;

--- a/src/deepspeech/model/README.md
+++ b/src/deepspeech/model/README.md
@@ -1,0 +1,10 @@
+# Place your language model files in this folder
+
+Check https://deepspeech.readthedocs.io/en/v0.6.1/USING.html#getting-the-pre-trained-model for instructions to download a compatible language model.
+
+Check https://github.com/mozilla/DeepSpeech for information about most current language models.
+
+```
+wget https://github.com/mozilla/DeepSpeech/releases/download/v0.6.1/deepspeech-0.6.1-models.tar.gz
+tar xvfz deepspeech-0.6.1-models.tar.gz
+```


### PR DESCRIPTION
In this pull request, I added this:

1. The folder structure to place language models and additional readme with information
2. A `createModel` function that can create a deepspeech language model object (https://deepspeech.readthedocs.io/en/v0.6.1/NodeJS-API.html#model) and enables the decoder using the language model (https://deepspeech.readthedocs.io/en/v0.6.1/NodeJS-API.html#Model.enableDecoderWithLM)
3. Both steps from 2. are executed when the Express server is started 

![createmodel](https://user-images.githubusercontent.com/27010409/79234698-f0cfba00-7e6a-11ea-914a-725a655a486a.PNG)
