### PR TITLE
Create frequency bar visualization of the audio

### DIFF
--- a/client/src/components/AudioVisualizer.js
+++ b/client/src/components/AudioVisualizer.js
@@ -1,6 +1,9 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { audioContext } from '../utils/audio';
 
-const AudioVisualizer = styled.div`
+const AudioWaveform = styled.canvas`
   display: flex;
   align-items: center;
   font-size: 20px;
@@ -8,5 +11,26 @@ const AudioVisualizer = styled.div`
   min-height: 100px;
   color: ${(props) => props.theme.colors.secondary};
 `;
+
+function AudioVisualizer(props) {
+  React.useEffect(() => {
+    if (props.isRecording) {
+      // Create audio analyser from audio context
+      const audioAnalyser = audioContext.createAnalyser();
+
+      // Set Fast Fourier Transform (ttf) to frequency domain
+      audioAnalyser.fftSize = 256;
+
+      console.log(audioAnalyser);
+    } else {
+      // stopped recording
+    }
+  }, [props.isRecording]);
+  return <AudioWaveform></AudioWaveform>;
+}
+
+AudioVisualizer.propTypes = {
+  isRecording: PropTypes.bool,
+};
 
 export default AudioVisualizer;

--- a/client/src/components/AudioVisualizer.js
+++ b/client/src/components/AudioVisualizer.js
@@ -29,15 +29,14 @@ function AudioVisualizer(props) {
     canvasContext.fillStyle = theme.colors.background;
     canvasContext.fillRect(0, 0, width, height);
 
-    const barWidth = (width / bufferLength) * 2.5;
+    const barWidth = (width / bufferLength) * 0.35;
     let barHeight;
-    let x = 0;
+    let x = barWidth / 2;
 
     for (let i = 0; i < bufferLength; i++) {
       barHeight = dataArray[i] / 2;
 
       // Draw bar top
-      //canvasContext.fillStyle = 'rgb(' + (barHeight + 100) + ',50,50)';
       canvasContext.fillStyle = theme.colors.secondary;
       canvasContext.fillRect(
         x,
@@ -68,7 +67,7 @@ function AudioVisualizer(props) {
       );
       canvasContext.fill();
 
-      x += barWidth + 20;
+      x += barWidth + (width / bufferLength) * 0.65;
     }
   }
 
@@ -79,7 +78,7 @@ function AudioVisualizer(props) {
       mediaStreamSource.connect(audioAnalyser);
 
       // Set Fast Fourier Transform (ttf) to frequency domain
-      audioAnalyser.fftSize = 256;
+      audioAnalyser.fftSize = 32;
       bufferLength = audioAnalyser.frequencyBinCount;
       dataArray = new Uint8Array(bufferLength);
 
@@ -88,8 +87,6 @@ function AudioVisualizer(props) {
       AudioWaveFormCanvas.height = AudioWaveFormCanvas.offsetHeight;
       width = AudioWaveFormCanvas.offsetWidth;
       height = AudioWaveFormCanvas.offsetHeight;
-      console.log(width);
-      console.log(height);
 
       // clear previous visualization in canvas
       canvasContext.clearRect(0, 0, width, height);

--- a/client/src/components/AudioVisualizer.js
+++ b/client/src/components/AudioVisualizer.js
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import theme from '../theme';
 import { audioContext, mediaStreamSource } from '../utils/audio';
 
 const AudioWaveForm = styled.canvas`
@@ -25,7 +26,7 @@ function AudioVisualizer(props) {
 
     audioAnalyser.getByteFrequencyData(dataArray);
 
-    canvasContext.fillStyle = 'rgb(0, 0, 0)';
+    canvasContext.fillStyle = theme.colors.background;
     canvasContext.fillRect(0, 0, width, height);
 
     const barWidth = (width / bufferLength) * 2.5;
@@ -35,10 +36,39 @@ function AudioVisualizer(props) {
     for (let i = 0; i < bufferLength; i++) {
       barHeight = dataArray[i] / 2;
 
-      canvasContext.fillStyle = 'rgb(' + (barHeight + 100) + ',50,50)';
-      canvasContext.fillRect(x, height - barHeight / 2, barWidth, barHeight);
+      // Draw bar top
+      //canvasContext.fillStyle = 'rgb(' + (barHeight + 100) + ',50,50)';
+      canvasContext.fillStyle = theme.colors.secondary;
+      canvasContext.fillRect(
+        x,
+        height / 2 - barHeight / 2,
+        barWidth,
+        barHeight
+      );
 
-      x += barWidth + 1;
+      // Draw rounded end top
+      canvasContext.beginPath();
+      canvasContext.arc(
+        x + barWidth / 2,
+        height / 2 - barHeight / 2,
+        barWidth / 2,
+        0,
+        2 * Math.PI
+      );
+      canvasContext.fill();
+
+      // Draw rounded end bottom
+      canvasContext.beginPath();
+      canvasContext.arc(
+        x + barWidth / 2,
+        height / 2 + barHeight / 2,
+        barWidth / 2,
+        0,
+        2 * Math.PI
+      );
+      canvasContext.fill();
+
+      x += barWidth + 20;
     }
   }
 
@@ -54,6 +84,8 @@ function AudioVisualizer(props) {
       dataArray = new Uint8Array(bufferLength);
 
       canvasContext = AudioWaveFormCanvas.getContext('2d');
+      AudioWaveFormCanvas.width = AudioWaveFormCanvas.offsetWidth;
+      AudioWaveFormCanvas.height = AudioWaveFormCanvas.offsetHeight;
       width = AudioWaveFormCanvas.offsetWidth;
       height = AudioWaveFormCanvas.offsetHeight;
       console.log(width);

--- a/client/src/components/AudioVisualizer.js
+++ b/client/src/components/AudioVisualizer.js
@@ -11,8 +11,9 @@ const AudioWaveForm = styled.canvas`
 `;
 
 function AudioVisualizer(props) {
+  const [animationFrameId, setAnimationFrameId] = React.useState();
+
   const canvas = useRef(null);
-  const AudioWaveFormCanvas = canvas.current;
 
   let audioAnalyser;
   let bufferLength;
@@ -22,21 +23,18 @@ function AudioVisualizer(props) {
   let height;
 
   function draw() {
-    requestAnimationFrame(draw);
-
     audioAnalyser.getByteFrequencyData(dataArray);
-
     canvasContext.fillStyle = theme.colors.background;
     canvasContext.fillRect(0, 0, width, height);
 
     const barWidth = (width / bufferLength) * 0.35;
     let barHeight;
-    let x = barWidth / 2;
+    let x = barWidth;
 
     for (let i = 0; i < bufferLength; i++) {
       barHeight = dataArray[i] / 2;
 
-      // Draw bar top
+      // Draw bar
       canvasContext.fillStyle = theme.colors.secondary;
       canvasContext.fillRect(
         x,
@@ -67,33 +65,57 @@ function AudioVisualizer(props) {
       );
       canvasContext.fill();
 
+      // Update x for next bar position
       x += barWidth + (width / bufferLength) * 0.65;
     }
+
+    setAnimationFrameId(requestAnimationFrame(draw));
+  }
+
+  function initializeDrawing() {
+    canvasContext = canvas.current.getContext('2d');
+    // Create audio analyser from audio context and connect to media stream source from microphone
+    audioAnalyser = audioContext.createAnalyser();
+
+    mediaStreamSource.connect(audioAnalyser);
+
+    // We want to display 16 bars so Fast Fourier Transform (ttf) is set to 32 and Uint8Array is chosen
+    audioAnalyser.fftSize = 32;
+    bufferLength = audioAnalyser.frequencyBinCount;
+    dataArray = new Uint8Array(bufferLength);
+
+    // Reset canvas
+    resetCanvas(canvasContext);
+
+    // Start drawing
+    setAnimationFrameId(requestAnimationFrame(draw));
+  }
+
+  function stopDrawing() {
+    if (animationFrameId > 0) {
+      cancelAnimationFrame(animationFrameId);
+
+      // clear previous visualization in canvas
+      canvasContext = canvas.current.getContext('2d');
+      resetCanvas(canvasContext);
+    }
+  }
+
+  function resetCanvas(canvasContext) {
+    canvas.current.width = canvas.current.offsetWidth;
+    canvas.current.height = canvas.current.offsetHeight;
+    width = canvas.current.offsetWidth;
+    height = canvas.current.offsetHeight;
+
+    // clear previous visualization in canvas
+    canvasContext.clearRect(0, 0, width, height);
   }
 
   React.useEffect(() => {
     if (props.isRecording) {
-      // Create audio analyser from audio context
-      audioAnalyser = audioContext.createAnalyser();
-      mediaStreamSource.connect(audioAnalyser);
-
-      // Set Fast Fourier Transform (ttf) to frequency domain
-      audioAnalyser.fftSize = 32;
-      bufferLength = audioAnalyser.frequencyBinCount;
-      dataArray = new Uint8Array(bufferLength);
-
-      canvasContext = AudioWaveFormCanvas.getContext('2d');
-      AudioWaveFormCanvas.width = AudioWaveFormCanvas.offsetWidth;
-      AudioWaveFormCanvas.height = AudioWaveFormCanvas.offsetHeight;
-      width = AudioWaveFormCanvas.offsetWidth;
-      height = AudioWaveFormCanvas.offsetHeight;
-
-      // clear previous visualization in canvas
-      canvasContext.clearRect(0, 0, width, height);
-
-      draw();
+      initializeDrawing();
     } else {
-      // stopped recording
+      stopDrawing();
     }
   }, [props.isRecording]);
   return <AudioWaveForm ref={canvas} />;

--- a/client/src/components/AudioVisualizer.js
+++ b/client/src/components/AudioVisualizer.js
@@ -1,32 +1,73 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { audioContext } from '../utils/audio';
+import { audioContext, mediaStreamSource } from '../utils/audio';
 
-const AudioWaveform = styled.canvas`
-  display: flex;
-  align-items: center;
-  font-size: 20px;
-  font-family: MontSerrat;
-  min-height: 100px;
-  color: ${(props) => props.theme.colors.secondary};
+const AudioWaveForm = styled.canvas`
+  width: 100%;
+  max-width: 600px;
+  height: 150px;
 `;
 
 function AudioVisualizer(props) {
+  const canvas = useRef(null);
+  const AudioWaveFormCanvas = canvas.current;
+
+  let audioAnalyser;
+  let bufferLength;
+  let dataArray;
+  let canvasContext;
+  let width;
+  let height;
+
+  function draw() {
+    requestAnimationFrame(draw);
+
+    audioAnalyser.getByteFrequencyData(dataArray);
+
+    canvasContext.fillStyle = 'rgb(0, 0, 0)';
+    canvasContext.fillRect(0, 0, width, height);
+
+    const barWidth = (width / bufferLength) * 2.5;
+    let barHeight;
+    let x = 0;
+
+    for (let i = 0; i < bufferLength; i++) {
+      barHeight = dataArray[i] / 2;
+
+      canvasContext.fillStyle = 'rgb(' + (barHeight + 100) + ',50,50)';
+      canvasContext.fillRect(x, height - barHeight / 2, barWidth, barHeight);
+
+      x += barWidth + 1;
+    }
+  }
+
   React.useEffect(() => {
     if (props.isRecording) {
       // Create audio analyser from audio context
-      const audioAnalyser = audioContext.createAnalyser();
+      audioAnalyser = audioContext.createAnalyser();
+      mediaStreamSource.connect(audioAnalyser);
 
       // Set Fast Fourier Transform (ttf) to frequency domain
       audioAnalyser.fftSize = 256;
+      bufferLength = audioAnalyser.frequencyBinCount;
+      dataArray = new Uint8Array(bufferLength);
 
-      console.log(audioAnalyser);
+      canvasContext = AudioWaveFormCanvas.getContext('2d');
+      width = AudioWaveFormCanvas.offsetWidth;
+      height = AudioWaveFormCanvas.offsetHeight;
+      console.log(width);
+      console.log(height);
+
+      // clear previous visualization in canvas
+      canvasContext.clearRect(0, 0, width, height);
+
+      draw();
     } else {
       // stopped recording
     }
   }, [props.isRecording]);
-  return <AudioWaveform></AudioWaveform>;
+  return <AudioWaveForm ref={canvas} />;
 }
 
 AudioVisualizer.propTypes = {

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -16,11 +16,11 @@ function Notes() {
   });
   const placeholders = { title: 'Title', note: 'Note' };
 
-  function handleRecordButtonClick() {
+  async function handleRecordButtonClick() {
     if (!isRecording) {
-      setIsRecording(startRecording());
+      setIsRecording(await startRecording());
     } else {
-      setIsRecording(stopRecording());
+      setIsRecording(await stopRecording());
       setNoteContent({
         text: noteContent.text.trim() + ' ' + noteContent.recognizedText.trim(),
         recognizedText: '',
@@ -84,7 +84,7 @@ function Notes() {
           />
         )}
       </NoteContainer>
-      <AudioVisualizer>{isRecording ? 'listening...' : ''}</AudioVisualizer>
+      <AudioVisualizer isRecording={isRecording} />
       <RecordButton
         isRecording={isRecording}
         onRecordButtonClick={handleRecordButtonClick}

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -18,9 +18,11 @@ function Notes() {
 
   async function handleRecordButtonClick() {
     if (!isRecording) {
-      setIsRecording(await startRecording());
+      await startRecording();
+      setIsRecording(true);
     } else {
-      setIsRecording(await stopRecording());
+      await stopRecording();
+      setIsRecording(false);
       setNoteContent({
         text: noteContent.text.trim() + ' ' + noteContent.recognizedText.trim(),
         recognizedText: '',

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -81,7 +81,7 @@ function Notes() {
         ) : (
           <NoteContent
             onChange={handleNoteContentChange}
-            value={noteContent.text}
+            value={noteContent.text.trim()}
             placeholder={placeholders.note}
           />
         )}

--- a/client/src/utils/audio.js
+++ b/client/src/utils/audio.js
@@ -113,4 +113,10 @@ function processAudio(audioWorkletNode, downsampler, sampleRate, socket) {
   return audioWorkletNode;
 }
 
-export { startRecording, stopRecording, getSocket, audioContext };
+export {
+  startRecording,
+  stopRecording,
+  getSocket,
+  audioContext,
+  mediaStreamSource,
+};

--- a/client/src/utils/audio.js
+++ b/client/src/utils/audio.js
@@ -76,7 +76,6 @@ function stopRecording() {
   if (audioContext) {
     audioContext.close();
   }
-  return false;
 }
 
 async function getMediastreamFromMicrophone() {

--- a/client/src/utils/audio.js
+++ b/client/src/utils/audio.js
@@ -113,4 +113,4 @@ function processAudio(audioWorkletNode, downsampler, sampleRate, socket) {
   return audioWorkletNode;
 }
 
-export { startRecording, stopRecording, getSocket };
+export { startRecording, stopRecording, getSocket, audioContext };

--- a/client/src/utils/audio.js
+++ b/client/src/utils/audio.js
@@ -76,6 +76,8 @@ function stopRecording() {
   if (audioContext) {
     audioContext.close();
   }
+
+  return true;
 }
 
 async function getMediastreamFromMicrophone() {


### PR DESCRIPTION
Deployment: https://dev.deepspeech-notes.haupt.digital

In this pull request, I added a visualization of the audio coming in from the microphone. For this, I use a `canvas`. While recording, the application draws 16 frequency bars. The data for these is created using the `web audio API` `createAnalyser` method.

![audio visualizer](https://user-images.githubusercontent.com/27010409/80411413-77a17f80-88cc-11ea-82a7-07a6b20a635e.PNG)

deepscan is giving me a hard time with some error message but when I try to apply the fix, my "stop recording" functionality does not reset the visualization anymore. 

![deepscan](https://user-images.githubusercontent.com/27010409/80455859-d39bf080-892c-11ea-8cd5-b79ec554ecf6.PNG)
