### PR TITLE
Automatic scroll to new transcribed text / custom scroll bars / fadeout text from top

### DIFF
--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -5,6 +5,7 @@ function GlobalStyle() {
   return (
     <Global
       styles={(theme) => css`
+        @import url('https://fonts.googleapis.com/css?family=Montserrat&display=swap');
         *,
         *:before,
         *:after {

--- a/client/src/components/NoteContent.js
+++ b/client/src/components/NoteContent.js
@@ -4,17 +4,33 @@ import noteBaseStyles from './noteBaseStyles';
 const NoteContent = styled.textarea`
   ${noteBaseStyles};
   font-size: 24px;
-  font-family: MontSerrat;
   color: ${(props) => props.theme.colors.primary};
   margin-bottom: 12.5px;
   flex-grow: 2;
+  padding-right: 10px;
+  overflow: hidden;
   &:focus,
   &:hover {
     box-shadow: 0 0 0 2px ${(props) => props.theme.colors.altTwo};
+    padding-right: 0px;
+    overflow-y: scroll;
   }
   &::placeholder {
     color: ${(props) => props.theme.colors.altTwo};
     opacity: 0.4;
+  }
+  &::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: ${(props) => props.theme.colors.light};
   }
 `;
 

--- a/client/src/components/NoteContentReadOnly.js
+++ b/client/src/components/NoteContentReadOnly.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import TextChunk from '../components/TextChunk';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
@@ -11,40 +11,67 @@ const NoteContentTextFromAudio = styled.div`
   color: ${(props) => props.theme.colors.primary};
   margin-bottom: 12.5px;
   flex-grow: 2;
-  &:focus,
-  &:hover {
-    box-shadow: 0 0 0 2px ${(props) => props.theme.colors.altTwo};
-  }
   &:empty::before {
   color: ${(props) => props.theme.colors.altTwo};
   opacity: 0.4;
   content: "${(props) => props.placeholder}";
   }
+  overflow: hidden;
+  height: 283px;
+`;
+
+const FadeoutText = styled.div`
+  height: 150px;
+  margin-bottom: -150px;
+  width: 100%;
+  z-index: 2000;
+  background-image: linear-gradient(
+    to top,
+    rgba(255, 0, 0, 0),
+    rgba(79, 66, 112, 1)
+  );
 `;
 
 function NoteContentReadOnly(props) {
+  const [showFadeoutText, setShowFadeoutText] = React.useState(false);
+  const scrollReference = useRef(null);
+
+  React.useEffect(() => {
+    // Scroll to bottom of noteContent div when new text appears
+    scrollReference.current.scrollTop = scrollReference.current.scrollHeight;
+    scrollReference.current.scrollHeight > 290
+      ? setShowFadeoutText(true)
+      : setShowFadeoutText(false);
+  }, [props.noteContent.recognizedText]);
+
   return (
-    <NoteContentTextFromAudio placeholder={props.placeholder}>
-      {props.noteContent.text !== '' && (
-        <TextChunk>{props.noteContent.text}</TextChunk>
-      )}
-      {props.noteContent.recognizedText !== '' && (
-        <CSSTransitionGroup
-          transitionName="fadeIn"
-          transitionAppear={true}
-          transitionLeave={false}
-          transitionEnterTimeout={300}
-          transitionAppearTimeout={300}
-        >
-          <TextChunk
-            key={props.noteContent.text + props.noteContent.recognizedText}
-            isNew={true}
+    <>
+      {showFadeoutText && <FadeoutText />}
+      <NoteContentTextFromAudio
+        ref={scrollReference}
+        placeholder={props.placeholder}
+      >
+        {props.noteContent.text !== '' && (
+          <TextChunk>{props.noteContent.text}</TextChunk>
+        )}
+        {props.noteContent.recognizedText !== '' && (
+          <CSSTransitionGroup
+            transitionName="fadeIn"
+            transitionAppear={true}
+            transitionLeave={false}
+            transitionEnterTimeout={300}
+            transitionAppearTimeout={300}
           >
-            {props.noteContent.recognizedText}
-          </TextChunk>
-        </CSSTransitionGroup>
-      )}
-    </NoteContentTextFromAudio>
+            <TextChunk
+              key={props.noteContent.text + props.noteContent.recognizedText}
+              isNew={true}
+            >
+              {props.noteContent.recognizedText}
+            </TextChunk>
+          </CSSTransitionGroup>
+        )}
+      </NoteContentTextFromAudio>
+    </>
   );
 }
 

--- a/client/src/components/noteBaseStyles.js
+++ b/client/src/components/noteBaseStyles.js
@@ -1,8 +1,8 @@
 import { css } from '@emotion/core';
 
-const noteBaseStyles = css`
+const noteBaseStyles = (props) => css`
   font-family: MontSerrat;
-  caret-color: ${(props) => props.theme.colors.secondary};
+  caret-color: ${props.theme.colors.secondary};
   background: transparent;
   border: none;
   outline: none;

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -13,7 +13,7 @@ function Notes() {
   const { noteId } = useParams();
   const [currentNodeId, setCurrentNodeId] = React.useState({});
   const [isRecording, setIsRecording] = React.useState(false);
-  const [noteTitle, setNoteTitle] = React.useState();
+  const [noteTitle, setNoteTitle] = React.useState('');
   const [noteContent, setNoteContent] = React.useState({
     text: '',
     recognizedText: '',
@@ -80,7 +80,7 @@ function Notes() {
     if (!isRecording) {
       return;
     }
-
+    addRecognizedText('Let us add some ideas');
     // While recording, add new text chunks
     function handleRecognize(recognized) {
       addRecognizedText(recognized.text);

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -80,7 +80,7 @@ function Notes() {
     if (!isRecording) {
       return;
     }
-    addRecognizedText('Let us add some ideas');
+
     // While recording, add new text chunks
     function handleRecognize(recognized) {
       addRecognizedText(recognized.text);


### PR DESCRIPTION
Deployment: https://dev.deepspeech-notes.haupt.digital

In this pull request, I added three things:

-  While recording, the note will automatically scroll to the bottom where the newly transcribed text appears. This obviously only happens, when there is enough text to fill the complete note.


- While recording, a fadeout will be added to the top of the text if the note is long enough.

- A custom scrollbar was added when text is long enough and you hover over the note

Fadeout from top:

![fadeout](https://user-images.githubusercontent.com/27010409/80691573-be5fc700-8ad0-11ea-8052-b3209ca2e1ea.png)

Custom scroll bar:

![custom scrollbar](https://user-images.githubusercontent.com/27010409/80691739-f404b000-8ad0-11ea-9db5-1a095cdf9635.png)
