### PR TITLE
Create list view of all previously entered notes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
 import theme from './theme';
 import Container from './components/Container';
 import Notes from './pages/Notes';
+import Note from './pages/Note';
 import About from './pages/About';
 import Statistics from './pages/Statistics';
 
@@ -17,14 +18,18 @@ function App() {
           <Switch>
             <Route path="/" exact>
               Demo links:
+              <Link to="/notes">List all notes</Link>
               <Link to="/note">Create new note</Link>
               <Link to="/note/5ea98269c610ed2641427200">See existing note</Link>
             </Route>
             <Route path="/note/:noteId" exact>
+              <Note />
+            </Route>
+            <Route path="/notes" exact>
               <Notes />
             </Route>
             <Route path="/note" exact>
-              <Notes />
+              <Note />
             </Route>
             <Route path="/about">
               <About />

--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -5,6 +5,7 @@ function GlobalStyle() {
   return (
     <Global
       styles={(theme) => css`
+        @import url('https://fonts.googleapis.com/css?family=Montserrat&display=swap');
         *,
         *:before,
         *:after {

--- a/client/src/components/Divider.js
+++ b/client/src/components/Divider.js
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const Divider = styled.div`
+  display: block;
+  width: 90px;
+  height: 2px;
+  background: ${(props) => props.theme.colors.altOne};
+  margin: 1rem;
+`;
+
+export default Divider;

--- a/client/src/components/NoteContent.js
+++ b/client/src/components/NoteContent.js
@@ -6,7 +6,7 @@ const NoteContent = styled.textarea`
   font-size: 24px;
   font-family: MontSerrat;
   color: ${(props) => props.theme.colors.primary};
-  margin-bottom: 12.5px;
+  margin: 6px 0;
   flex-grow: 2;
   &:focus,
   &:hover {

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+const NoteCardListView = styled.div`
+  background: transparent;
+  border: none;
+  outline: none;
+  resize: none;
+  border-radius: 5px;
+  padding: 1rem;
+  transition: 0.3s;
+  margin-bottom: 12.5px;
+  max-width: 195px;
+  cursor: pointer;
+  box-shadow: 0 0 0 2px ${(props) => props.theme.colors.light};
+  &:hover {
+    box-shadow: 0 0 0 2px ${(props) => props.theme.colors.altTwo};
+  }
+`;
+
+const NoteTitleListView = styled.p`
+  font-family: MontSerrat;
+  font-size: 20px;
+  font-weight: bold;
+  color: ${(props) => props.theme.colors.secondary};
+  margin: 0;
+`;
+
+const NoteContentListView = styled.p`
+  font-family: MontSerrat;
+  font-size: 18px;
+  margin: 0;
+`;
+
+function NoteListView(props) {
+  return (
+    <NoteCardListView>
+      {props.noteHasTitle && (
+        <NoteTitleListView>{props.title}</NoteTitleListView>
+      )}
+      {props.noteHasContent && (
+        <NoteContentListView>
+          {props.content.substring(0, 150)}
+        </NoteContentListView>
+      )}
+    </NoteCardListView>
+  );
+}
+
+NoteListView.propTypes = {
+  noteHasTitle: PropTypes.bool,
+  noteHasContent: PropTypes.bool,
+  title: PropTypes.string,
+  content: PropTypes.string,
+};
+
+export default NoteListView;

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
@@ -34,14 +35,20 @@ const NoteContentListView = styled.p`
 `;
 
 function NoteListView(props) {
+  const history = useHistory();
+
+  function handleNoteListViewClick(noteId) {
+    history.push(`/note/${noteId}`);
+  }
+
   return (
-    <NoteCardListView>
+    <NoteCardListView onClick={() => handleNoteListViewClick(props.noteId)}>
       {props.noteHasTitle && (
         <NoteTitleListView>{props.title}</NoteTitleListView>
       )}
       {props.noteHasContent && (
         <NoteContentListView>
-          {props.content.substring(0, 150)}
+          {props.content.substring(0, 100)}
         </NoteContentListView>
       )}
     </NoteCardListView>
@@ -49,6 +56,7 @@ function NoteListView(props) {
 }
 
 NoteListView.propTypes = {
+  noteId: PropTypes.string,
   noteHasTitle: PropTypes.bool,
   noteHasContent: PropTypes.bool,
   title: PropTypes.string,

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -26,6 +26,14 @@ const NoteTitleListView = styled.p`
   font-weight: bold;
   color: ${(props) => props.theme.colors.secondary};
   margin: 0;
+  &:after {
+    content: '';
+    display: block;
+    width: 90px;
+    height: 2px;
+    background: ${(props) => props.theme.colors.altOne};
+    margin: 1rem 0;
+  }
 `;
 
 const NoteContentListView = styled.p`

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -12,7 +12,7 @@ const NoteCardListView = styled.div`
   padding: 1rem;
   transition: 0.3s;
   margin-bottom: 12.5px;
-  max-width: 195px;
+  width: 100%;
   cursor: pointer;
   box-shadow: 0 0 0 2px ${(props) => props.theme.colors.light};
   &:hover {
@@ -48,7 +48,7 @@ function NoteListView(props) {
       )}
       {props.noteHasContent && (
         <NoteContentListView>
-          {props.content.substring(0, 100)}
+          {props.content.substring(0, 250)}
         </NoteContentListView>
       )}
     </NoteCardListView>

--- a/client/src/components/NoteTitle.js
+++ b/client/src/components/NoteTitle.js
@@ -6,7 +6,7 @@ const NoteTitle = styled.input`
   font-size: 30px;
   font-weight: bold;
   color: ${(props) => props.theme.colors.secondary};
-  margin: 12.5px 0;
+  margin: 6px 0;
   &:focus,
   &:hover {
     box-shadow: 0 0 0 2px ${(props) => props.theme.colors.altTwo};

--- a/client/src/components/NotesList.js
+++ b/client/src/components/NotesList.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import NoteListView from './NoteListView';
+
+const NotesListWrapper = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  max-width: 600px;
+  width: 100%;
+`;
+
+function NotesList(props) {
+  const renderNoteList = props.notes.map((note) => {
+    const noteHasTitle = note.title ? true : false;
+    const noteHasContent = note.content ? true : false;
+    if (noteHasTitle || noteHasContent) {
+      return (
+        <NoteListView
+          key={note._id}
+          noteHasTitle={noteHasTitle}
+          noteHasContent={noteHasContent}
+          content={note.content}
+          title={note.title}
+        />
+      );
+    }
+  });
+
+  return <NotesListWrapper>{renderNoteList}</NotesListWrapper>;
+}
+
+NotesList.propTypes = {
+  notes: PropTypes.array,
+};
+
+export default NotesList;

--- a/client/src/components/NotesList.js
+++ b/client/src/components/NotesList.js
@@ -4,9 +4,6 @@ import styled from '@emotion/styled';
 import NoteListView from './NoteListView';
 
 const NotesListWrapper = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
   max-width: 600px;
   width: 100%;
 `;

--- a/client/src/components/NotesList.js
+++ b/client/src/components/NotesList.js
@@ -19,6 +19,7 @@ function NotesList(props) {
       return (
         <NoteListView
           key={note._id}
+          noteId={note._id}
           noteHasTitle={noteHasTitle}
           noteHasContent={noteHasContent}
           content={note.content}

--- a/client/src/pages/Note.js
+++ b/client/src/pages/Note.js
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { getNote, postNote, updateNote } from '../api/notes';
 import NoteContainer from '../components/NoteContainer';
 import NoteTitle from '../components/NoteTitle';
+import Divider from '../components/Divider';
 import NoteContent from '../components/NoteContent';
 import NoteContentReadOnly from '../components/NoteContentReadOnly';
 import AudioVisualizer from '../components/AudioVisualizer';
@@ -103,6 +104,7 @@ function Notes() {
           value={noteTitle}
           placeholder={placeholders.title}
         />
+        <Divider />
         {isRecording ? (
           <NoteContentReadOnly
             noteContent={noteContent}

--- a/client/src/pages/Note.js
+++ b/client/src/pages/Note.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { getNote, postNote, updateNote } from '../api/notes';
+import NoteContainer from '../components/NoteContainer';
+import NoteTitle from '../components/NoteTitle';
+import NoteContent from '../components/NoteContent';
+import NoteContentReadOnly from '../components/NoteContentReadOnly';
+import AudioVisualizer from '../components/AudioVisualizer';
+import RecordButton from '../components/RecordButton';
+import { startRecording, stopRecording, getSocket } from '../utils/audio';
+
+function Notes() {
+  const { noteId } = useParams();
+  const [currentNodeId, setCurrentNodeId] = React.useState({});
+  const [isRecording, setIsRecording] = React.useState(false);
+  const [noteTitle, setNoteTitle] = React.useState();
+  const [noteContent, setNoteContent] = React.useState({
+    text: '',
+    recognizedText: '',
+  });
+  const placeholders = { title: 'Title', note: 'Note' };
+
+  async function saveNote() {
+    if (currentNodeId) {
+      // Update note in DB if there is a noteId collected from parameters
+      updateNote({ noteTitle, noteContent }, currentNodeId);
+    } else {
+      // Create new note in DB
+      const createdNoteId = await postNote({ noteTitle, noteContent });
+      setCurrentNodeId(createdNoteId);
+    }
+  }
+
+  async function handleRecordButtonClick() {
+    if (!isRecording) {
+      await startRecording();
+      setIsRecording(true);
+    } else {
+      await stopRecording();
+      setIsRecording(false);
+      setNoteContent({
+        text: noteContent.text.trim() + ' ' + noteContent.recognizedText.trim(),
+        recognizedText: '',
+      });
+
+      saveNote();
+    }
+  }
+
+  function addRecognizedText(recognizedText) {
+    setNoteContent((noteContent) => {
+      const updatedNoteContent = {
+        text: noteContent.text.trim() + ' ' + noteContent.recognizedText.trim(),
+        recognizedText: ' ' + recognizedText,
+      };
+      return updatedNoteContent;
+    });
+  }
+
+  function handleNoteTitleChange(event) {
+    setNoteTitle(event.target.value);
+  }
+
+  function handleNoteContentChange(event) {
+    setNoteContent({ text: event.target.value, recognizedText: '' });
+  }
+
+  React.useEffect(() => {
+    if (noteId) {
+      // Get note title and content if noteId is set
+      getNote(noteId).then((note) => {
+        setNoteTitle(note.title);
+        setNoteContent({ text: note.content, recognizedText: '' });
+      });
+    }
+    setCurrentNodeId(noteId);
+  }, [noteId]);
+
+  React.useEffect(() => {
+    if (!isRecording) {
+      return;
+    }
+
+    // While recording, add new text chunks
+    function handleRecognize(recognized) {
+      addRecognizedText(recognized.text);
+    }
+
+    const socket = getSocket();
+    socket.on('recognize', handleRecognize);
+
+    return () => {
+      socket.removeListener('recognize', handleRecognize);
+    };
+  }, [isRecording]);
+
+  return (
+    <>
+      <NoteContainer>
+        <NoteTitle
+          onChange={handleNoteTitleChange}
+          onBlur={saveNote}
+          value={noteTitle}
+          placeholder={placeholders.title}
+        />
+        {isRecording ? (
+          <NoteContentReadOnly
+            noteContent={noteContent}
+            placeholder={placeholders.note}
+          />
+        ) : (
+          <NoteContent
+            onChange={handleNoteContentChange}
+            onBlur={saveNote}
+            value={noteContent.text}
+            placeholder={placeholders.note}
+          />
+        )}
+      </NoteContainer>
+      <AudioVisualizer isRecording={isRecording} />
+      <RecordButton
+        isRecording={isRecording}
+        onRecordButtonClick={handleRecordButtonClick}
+      />
+    </>
+  );
+}
+
+export default Notes;

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -1,129 +1,22 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
-import { getNote, postNote, updateNote } from '../api/notes';
-import NoteContainer from '../components/NoteContainer';
-import NoteTitle from '../components/NoteTitle';
-import NoteContent from '../components/NoteContent';
-import NoteContentReadOnly from '../components/NoteContentReadOnly';
-import AudioVisualizer from '../components/AudioVisualizer';
-import RecordButton from '../components/RecordButton';
-import { startRecording, stopRecording, getSocket } from '../utils/audio';
+import { getNotes } from '../api/notes';
+import NotesList from '../components/NotesList';
 
-function Notes() {
-  const { noteId } = useParams();
-  const [currentNodeId, setCurrentNodeId] = React.useState({});
-  const [isRecording, setIsRecording] = React.useState(false);
-  const [noteTitle, setNoteTitle] = React.useState();
-  const [noteContent, setNoteContent] = React.useState({
-    text: '',
-    recognizedText: '',
-  });
-  const placeholders = { title: 'Title', note: 'Note' };
-
-  async function saveNote() {
-    if (currentNodeId) {
-      // Update note in DB if there is a noteId collected from parameters
-      updateNote({ noteTitle, noteContent }, currentNodeId);
-    } else {
-      // Create new note in DB
-      const createdNoteId = await postNote({ noteTitle, noteContent });
-      setCurrentNodeId(createdNoteId);
-    }
-  }
-
-  async function handleRecordButtonClick() {
-    if (!isRecording) {
-      await startRecording();
-      setIsRecording(true);
-    } else {
-      await stopRecording();
-      setIsRecording(false);
-      setNoteContent({
-        text: noteContent.text.trim() + ' ' + noteContent.recognizedText.trim(),
-        recognizedText: '',
-      });
-
-      saveNote();
-    }
-  }
-
-  function addRecognizedText(recognizedText) {
-    setNoteContent((noteContent) => {
-      const updatedNoteContent = {
-        text: noteContent.text.trim() + ' ' + noteContent.recognizedText.trim(),
-        recognizedText: ' ' + recognizedText,
-      };
-      return updatedNoteContent;
+function ListNotes() {
+  const [notes, setNotes] = React.useState([]);
+  React.useEffect(() => {
+    // Get all notes
+    getNotes().then((notes) => {
+      setNotes(notes);
     });
-  }
-
-  function handleNoteTitleChange(event) {
-    setNoteTitle(event.target.value);
-  }
-
-  function handleNoteContentChange(event) {
-    setNoteContent({ text: event.target.value, recognizedText: '' });
-  }
-
-  React.useEffect(() => {
-    if (noteId) {
-      // Get note title and content if noteId is set
-      getNote(noteId).then((note) => {
-        setNoteTitle(note.title);
-        setNoteContent({ text: note.content, recognizedText: '' });
-      });
-    }
-    setCurrentNodeId(noteId);
-  }, [noteId]);
-
-  React.useEffect(() => {
-    if (!isRecording) {
-      return;
-    }
-
-    // While recording, add new text chunks
-    function handleRecognize(recognized) {
-      addRecognizedText(recognized.text);
-    }
-
-    const socket = getSocket();
-    socket.on('recognize', handleRecognize);
-
-    return () => {
-      socket.removeListener('recognize', handleRecognize);
-    };
-  }, [isRecording]);
+  }, []);
 
   return (
     <>
-      <NoteContainer>
-        <NoteTitle
-          onChange={handleNoteTitleChange}
-          onBlur={saveNote}
-          value={noteTitle}
-          placeholder={placeholders.title}
-        />
-        {isRecording ? (
-          <NoteContentReadOnly
-            noteContent={noteContent}
-            placeholder={placeholders.note}
-          />
-        ) : (
-          <NoteContent
-            onChange={handleNoteContentChange}
-            onBlur={saveNote}
-            value={noteContent.text}
-            placeholder={placeholders.note}
-          />
-        )}
-      </NoteContainer>
-      <AudioVisualizer isRecording={isRecording} />
-      <RecordButton
-        isRecording={isRecording}
-        onRecordButtonClick={handleRecordButtonClick}
-      />
+      <div>List of notes</div>
+      {notes && <NotesList notes={notes} />}
     </>
   );
 }
 
-export default Notes;
+export default ListNotes;

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -1,20 +1,30 @@
 import React from 'react';
 import { getNotes } from '../api/notes';
+import Container from '../components/Container';
 import NotesList from '../components/NotesList';
 
 function ListNotes() {
   const [notes, setNotes] = React.useState([]);
+  const [isLoading, setIsLoading] = React.useState(true);
   React.useEffect(() => {
     // Get all notes
     getNotes().then((notes) => {
       setNotes(notes);
+      setIsLoading(false);
     });
   }, []);
 
+  if (isLoading) {
+    return <Container>Loading...</Container>;
+  }
+
   return (
     <>
-      <div>List of notes</div>
-      {notes && <NotesList notes={notes} />}
+      {notes.length > 0 ? (
+        <NotesList notes={notes} />
+      ) : (
+        <Container>Go ahead and create your first note :-)</Container>
+      )}
     </>
   );
 }


### PR DESCRIPTION
In this pull request, I added a list view of all notes. 

- The list view does understand, if a note has a title or content and will only display the relevant part.
- A click on an item in the list view will lead you to the detail view of the note, where it can be edited.
- I also added `Divider` component to visually help to see the difference between title and content.

You can test it like this:
Go to > https://dev.deepspeech-notes.haupt.digital > Click on "List all notes" > Click on any note

![localhost_3000_notes(iPhone 6_7_8)](https://user-images.githubusercontent.com/27010409/80812812-ff3b0700-8bc8-11ea-9b05-c05b89bbf5da.png)
