### PR TITLE
Add search functionality with highlighted search results

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17859,8 +17859,7 @@
     "throttle-debounce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
-      "integrity": "sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==",
-      "dev": true
+      "integrity": "sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg=="
     },
     "through": {
       "version": "2.3.8",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "react-transition-group": "^1.2.1",
-    "socket.io-client": "^2.3.0"
+    "socket.io-client": "^2.3.0",
+    "throttle-debounce": "^2.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,8 +4,6 @@ import { ThemeProvider } from 'emotion-theming';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import theme from './theme';
 import Header from './components/Header';
-import Menu from './components/Menu';
-import MenuIcon from './components/MenuIcon';
 import Container from './components/Container';
 import Notes from './pages/Notes';
 import Note from './pages/Note';
@@ -17,10 +15,7 @@ function App() {
     <ThemeProvider theme={theme}>
       <GlobalStyles />
       <Router>
-        <Header>
-          <Menu />
-          <MenuIcon />
-        </Header>
+        <Header />
         <Container>
           <Switch>
             <Route path="/" exact>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,8 @@ import GlobalStyles from './GlobalStyles';
 import { ThemeProvider } from 'emotion-theming';
 import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
 import theme from './theme';
+import Header from './components/Header';
+import MenuIcon from './components/MenuIcon';
 import Container from './components/Container';
 import Notes from './pages/Notes';
 import Note from './pages/Note';
@@ -13,6 +15,9 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyles />
+      <Header>
+        <MenuIcon />
+      </Header>
       <Container>
         <Router>
           <Switch>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import GlobalStyles from './GlobalStyles';
 import { ThemeProvider } from 'emotion-theming';
-import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
+import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import theme from './theme';
 import Header from './components/Header';
+import Menu from './components/Menu';
 import MenuIcon from './components/MenuIcon';
 import Container from './components/Container';
 import Notes from './pages/Notes';
@@ -15,23 +16,18 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyles />
-      <Header>
-        <MenuIcon />
-      </Header>
-      <Container>
-        <Router>
+      <Router>
+        <Header>
+          <Menu />
+          <MenuIcon />
+        </Header>
+        <Container>
           <Switch>
             <Route path="/" exact>
-              Demo links:
-              <Link to="/notes">List all notes</Link>
-              <Link to="/note">Create new note</Link>
-              <Link to="/note/5ea98269c610ed2641427200">See existing note</Link>
+              <Notes />
             </Route>
             <Route path="/note/:noteId" exact>
               <Note />
-            </Route>
-            <Route path="/notes" exact>
-              <Notes />
             </Route>
             <Route path="/note" exact>
               <Note />
@@ -43,8 +39,8 @@ function App() {
               <Statistics />
             </Route>
           </Switch>
-        </Router>
-      </Container>
+        </Container>
+      </Router>
     </ThemeProvider>
   );
 }

--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -17,6 +17,7 @@ function GlobalStyle() {
           font-family: 'Montserrat', sans-serif;
           background-color: ${theme.colors.background};
           color: ${theme.colors.primary};
+          overflow-x: hidden;
         }
         a,
         a:hover,

--- a/client/src/GlobalStyles.js
+++ b/client/src/GlobalStyles.js
@@ -17,7 +17,6 @@ function GlobalStyle() {
           font-family: 'Montserrat', sans-serif;
           background-color: ${theme.colors.background};
           color: ${theme.colors.primary};
-          overflow-x: hidden;
         }
         a,
         a:hover,

--- a/client/src/api/notes.js
+++ b/client/src/api/notes.js
@@ -11,8 +11,8 @@ export function getNote(noteId) {
     .then((response) => response.json());
 }
 
-export function getNotes() {
-  return fetch(`/api/notes/`, {
+export function getNotes(searchQuery) {
+  return fetch(`/api/notes/?q=${searchQuery}`, {
     method: 'GET',
   })
     .then((response) => {

--- a/client/src/assets/back.svg
+++ b/client/src/assets/back.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="41.139" height="27.952" viewBox="0 0 41.139 27.952">
+  <g id="Back_icon" data-name="Back icon" transform="translate(1.139 0.976)">
+    <line id="Linie_14" data-name="Linie 14" x2="40" transform="translate(0 13)" fill="none" stroke="#f4edda" stroke-width="3"/>
+    <line id="Linie_15" data-name="Linie 15" x1="12" y2="14" fill="none" stroke="#f4edda" stroke-width="3"/>
+    <line id="Linie_16" data-name="Linie 16" x1="12" y1="14" transform="translate(0 12)" fill="none" stroke="#f4edda" stroke-width="3"/>
+  </g>
+</svg>

--- a/client/src/assets/lens.svg
+++ b/client/src/assets/lens.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40.561" height="39.561" viewBox="0 0 40.561 39.561">
+  <g id="Gruppe_6" data-name="Gruppe 6" transform="translate(-1427 -47)">
+    <g id="Ellipse_24" data-name="Ellipse 24" transform="translate(1427 47)" fill="none" stroke="#f4edda" stroke-width="3">
+      <circle cx="16" cy="16" r="16" stroke="none"/>
+      <circle cx="16" cy="16" r="14.5" fill="none"/>
+    </g>
+    <line id="Linie_18" data-name="Linie 18" x2="13" y2="13" transform="translate(1453.5 72.5)" fill="none" stroke="#f4edda" stroke-width="3"/>
+  </g>
+</svg>

--- a/client/src/assets/loading.svg
+++ b/client/src/assets/loading.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin:auto;background:transparent;display:block;" width="200px" height="200px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+<g transform="translate(20 50)">
+<circle cx="0" cy="0" r="6" fill="#f4edda" transform="scale(0.598413 0.598413)">
+  <animateTransform attributeName="transform" type="scale" begin="-0.375s" calcMode="spline" keySplines="0.3 0 0.7 1;0.3 0 0.7 1" values="0;1;0" keyTimes="0;0.5;1" dur="1s" repeatCount="indefinite"></animateTransform>
+</circle>
+</g><g transform="translate(40 50)">
+<circle cx="0" cy="0" r="6" fill="#f4edda" transform="scale(0.250662 0.250662)">
+  <animateTransform attributeName="transform" type="scale" begin="-0.25s" calcMode="spline" keySplines="0.3 0 0.7 1;0.3 0 0.7 1" values="0;1;0" keyTimes="0;0.5;1" dur="1s" repeatCount="indefinite"></animateTransform>
+</circle>
+</g><g transform="translate(60 50)">
+<circle cx="0" cy="0" r="6" fill="#f4edda" transform="scale(0.0160892 0.0160892)">
+  <animateTransform attributeName="transform" type="scale" begin="-0.125s" calcMode="spline" keySplines="0.3 0 0.7 1;0.3 0 0.7 1" values="0;1;0" keyTimes="0;0.5;1" dur="1s" repeatCount="indefinite"></animateTransform>
+</circle>
+</g><g transform="translate(80 50)">
+<circle cx="0" cy="0" r="6" fill="#f4edda" transform="scale(0.0948685 0.0948685)">
+  <animateTransform attributeName="transform" type="scale" begin="0s" calcMode="spline" keySplines="0.3 0 0.7 1;0.3 0 0.7 1" values="0;1;0" keyTimes="0;0.5;1" dur="1s" repeatCount="indefinite"></animateTransform>
+</circle>
+</g>
+</svg>

--- a/client/src/assets/logo.svg
+++ b/client/src/assets/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="169" height="39" viewBox="0 0 169 39">
+  <g id="Gruppe_5" data-name="Gruppe 5" transform="translate(-1605 -483)">
+    <rect id="Rechteck_35" data-name="Rechteck 35" width="5" height="22" rx="2.5" transform="translate(1605 491)" fill="#fbc968"/>
+    <rect id="Rechteck_36" data-name="Rechteck 36" width="5" height="39" rx="2.5" transform="translate(1617 483)" fill="#fbc968"/>
+    <rect id="Rechteck_46" data-name="Rechteck 46" width="5" height="22" rx="2.5" transform="translate(1629 491)" fill="#fbc968"/>
+    <rect id="Rechteck_47" data-name="Rechteck 47" width="5" height="39" rx="2.5" transform="translate(1641 483)" fill="#fbc968"/>
+    <path id="Pfad_22" data-name="Pfad 22" d="M2.5,0A2.5,2.5,0,0,1,5,2.5v17a2.5,2.5,0,0,1-5,0V2.5A2.5,2.5,0,0,1,2.5,0Z" transform="translate(1653 491)" fill="#fbc968"/>
+    <text id="DeepSpeech_Notes" data-name="DeepSpeechNotes" transform="translate(1671 498)" fill="#fbc968" font-size="16" font-family="Montserrat-Light, Montserrat" font-weight="300"><tspan x="0" y="0">DeepSpeech</tspan><tspan y="0" font-family="Montserrat-SemiBold, Montserrat" font-weight="600"></tspan><tspan fill="#f4edda"><tspan x="0" y="19">Notes</tspan></tspan></text>
+  </g>
+</svg>

--- a/client/src/components/AudioVisualizer.js
+++ b/client/src/components/AudioVisualizer.js
@@ -7,7 +7,7 @@ import { audioContext, mediaStreamSource } from '../utils/audio';
 const AudioWaveForm = styled.canvas`
   width: 100%;
   max-width: 600px;
-  height: 150px;
+  height: 100px;
 `;
 
 function AudioVisualizer(props) {
@@ -32,7 +32,7 @@ function AudioVisualizer(props) {
     let x = barWidth;
 
     for (let i = 0; i < bufferLength; i++) {
-      barHeight = dataArray[i] / 2;
+      barHeight = dataArray[i] / 3;
 
       // Draw bar
       canvasContext.fillStyle = theme.colors.secondary;

--- a/client/src/components/BackLink.js
+++ b/client/src/components/BackLink.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ReactComponent as BackIcon } from '../assets/back.svg';
+import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
+
+const BackArrow = styled(BackIcon)`
+  margin: 6px;
+  cursor: pointer;
+`;
+
+function BackLink() {
+  return (
+    <Link to="/">
+      <BackArrow />
+    </Link>
+  );
+}
+
+export default BackLink;

--- a/client/src/components/Container.js
+++ b/client/src/components/Container.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 const Container = styled.div`
-  margin: 25px;
+  margin: 15px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/client/src/components/Divider.js
+++ b/client/src/components/Divider.js
@@ -5,7 +5,7 @@ const Divider = styled.div`
   width: 90px;
   height: 2px;
   background: ${(props) => props.theme.colors.altOne};
-  margin: 1rem;
+  margin: 5px 10px;
 `;
 
 export default Divider;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+const Header = styled.div`
+  width: 100%;
+  height: 90px;
+  padding: 1rem;
+`;
+
+export default Header;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,9 +1,30 @@
+import React from 'react';
 import styled from '@emotion/styled';
+import Menu from './Menu';
+import MenuIcon from './MenuIcon';
 
-const Header = styled.div`
+const NavigationBar = styled.div`
   width: 100%;
   height: 90px;
   padding: 1rem;
+  display: flex;
+  justify-content: flex-end;
 `;
+
+function Header() {
+  const [menuIsOpen, setMenuIsOpen] = React.useState(false);
+
+  function handleMenuIconClick() {
+    setMenuIsOpen(!menuIsOpen);
+    console.log(menuIsOpen);
+  }
+
+  return (
+    <NavigationBar>
+      <Menu menuIsOpen={menuIsOpen} />
+      <MenuIcon onMenuIconClick={handleMenuIconClick} menuIsOpen={menuIsOpen} />
+    </NavigationBar>
+  );
+}
 
 export default Header;

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -4,7 +4,7 @@ import Menu from './Menu';
 import { ReactComponent as Logo } from '../assets/logo.svg';
 import MenuIcon from './MenuIcon';
 
-const NavigationBar = styled.div`
+const Navigation = styled.header`
   width: 100%;
   padding: 15px;
   display: flex;
@@ -16,15 +16,14 @@ function Header() {
 
   function handleMenuIconClick() {
     setMenuIsOpen(!menuIsOpen);
-    console.log(menuIsOpen);
   }
 
   return (
-    <NavigationBar>
+    <Navigation>
       <Logo />
-      <Menu menuIsOpen={menuIsOpen} />
       <MenuIcon onMenuIconClick={handleMenuIconClick} menuIsOpen={menuIsOpen} />
-    </NavigationBar>
+      <Menu menuIsOpen={menuIsOpen} />
+    </Navigation>
   );
 }
 

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import Menu from './Menu';
+import { ReactComponent as Logo } from '../assets/logo.svg';
 import MenuIcon from './MenuIcon';
 
 const NavigationBar = styled.div`
@@ -8,7 +9,7 @@ const NavigationBar = styled.div`
   height: 90px;
   padding: 1rem;
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 `;
 
 function Header() {
@@ -21,6 +22,7 @@ function Header() {
 
   return (
     <NavigationBar>
+      <Logo />
       <Menu menuIsOpen={menuIsOpen} />
       <MenuIcon onMenuIconClick={handleMenuIconClick} menuIsOpen={menuIsOpen} />
     </NavigationBar>

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -6,8 +6,7 @@ import MenuIcon from './MenuIcon';
 
 const NavigationBar = styled.div`
   width: 100%;
-  height: 90px;
-  padding: 1rem;
+  padding: 15px;
   display: flex;
   justify-content: space-between;
 `;

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
+
+const MenuWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+`;
+
+const menuData = {
+  notes: { title: 'Your notes', link: '/', color: '#123123' },
+  statistics: { title: 'Statistics', link: '/statistics', color: '#123123' },
+  about: { title: 'About', link: '/about', color: '#123123' },
+};
+
+const menuItems = Object.values(menuData).map((item) => {
+  return (
+    <Link key={item.title} to={item.link}>
+      {item.title}
+    </Link>
+  );
+});
+
+function Menu() {
+  return <MenuWrapper>{menuItems}</MenuWrapper>;
+}
+
+export default Menu;

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -1,29 +1,75 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 const MenuWrapper = styled.div`
+  position: absolute;
+  height: 100vh;
+  width: 25%;
   display: flex;
   flex-direction: column;
-  position: absolute;
+  justify-content: space-around;
+  top: 0;
+  right: 0;
+  transition: transform 0.3s;
+
+  transform: ${(props) =>
+    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
+const MenuLinkCard = styled.div`
+  transform: ${(props) =>
+    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
+  transition: transform ${(props) => (props.index + 1) * 0.3}s;
+  border-radius: 25px 0 0 25px;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  background-color: ${(props) => props.backgroundColor};
+  z-index: ${(props) => props.index * -1};
+  margin-top: -35px;
+`;
+
+const MenuLink = styled(Link)`
+  font-size: 20px;
+  font-weight: bold;
+  padding-top: 25px;
+  text-decoration: none;
+  align-self: center;
 `;
 
 const menuData = {
-  notes: { title: 'Your notes', link: '/', color: '#123123' },
-  statistics: { title: 'Statistics', link: '/statistics', color: '#123123' },
-  about: { title: 'About', link: '/about', color: '#123123' },
+  notes: { title: 'Your notes', link: '/', color: '#78C1D4' },
+  statistics: { title: 'Statistics', link: '/statistics', color: '#029ECE' },
+  about: { title: 'About', link: '/about', color: '#160F43' },
 };
 
-const menuItems = Object.values(menuData).map((item) => {
-  return (
-    <Link key={item.title} to={item.link}>
-      {item.title}
-    </Link>
-  );
-});
+function Menu(props) {
+  const menuItems = Object.values(menuData).map((item, index) => {
+    return (
+      <MenuLinkCard
+        key={item.title}
+        menuIsOpen={props.menuIsOpen}
+        backgroundColor={item.color}
+        index={index}
+      >
+        <MenuLink to={item.link}>{item.title}</MenuLink>
+      </MenuLinkCard>
+    );
+  });
 
-function Menu() {
-  return <MenuWrapper>{menuItems}</MenuWrapper>;
+  return <MenuWrapper menuIsOpen={props.menuIsOpen}>{menuItems}</MenuWrapper>;
 }
+
+Menu.propTypes = {
+  menuIsOpen: PropTypes.bool,
+};
 
 export default Menu;

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -15,7 +15,7 @@ const MenuWrapper = styled.div`
   transition: transform 0.3s;
 
   transform: ${(props) =>
-    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
+    props.isOpen ? 'translateX(0)' : 'translateX(100%)'};
 
   @media (max-width: 768px) {
     width: 100%;
@@ -24,8 +24,8 @@ const MenuWrapper = styled.div`
 
 const MenuLinkCard = styled.div`
   transform: ${(props) =>
-    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
-  transition: transform ${(props) => (props.index + 1) * 0.3}s;
+    props.isOpen ? 'translateX(0)' : 'translateX(100%)'};
+  transition: transform ${(props) => props.slideInDelay}s;
   border-radius: 25px 0 0 25px;
   width: 100%;
   height: 100%;
@@ -33,7 +33,7 @@ const MenuLinkCard = styled.div`
   justify-content: center;
   align-content: center;
   background-color: ${(props) => props.backgroundColor};
-  z-index: ${(props) => props.index * -1};
+  z-index: ${(props) => props.slideInDelay};
   margin-top: -35px;
 `;
 
@@ -56,7 +56,7 @@ function Menu(props) {
     return (
       <MenuLinkCard
         key={item.title}
-        menuIsOpen={props.menuIsOpen}
+        isOpen={props.menuIsOpen}
         backgroundColor={item.color}
         slideInDelay={(index + 1) * 0.3}
       >
@@ -65,7 +65,7 @@ function Menu(props) {
     );
   });
 
-  return <MenuWrapper menuIsOpen={props.menuIsOpen}>{menuItems}</MenuWrapper>;
+  return <MenuWrapper isOpen={props.menuIsOpen}>{menuItems}</MenuWrapper>;
 }
 
 Menu.propTypes = {

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -15,7 +15,7 @@ const MenuWrapper = styled.div`
   transition: transform 0.3s;
 
   transform: ${(props) =>
-    props.menuIsOpen ? 'translateX(0)' : 'translateX(50%)'};
+    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
 
   @media (max-width: 768px) {
     width: 100%;
@@ -24,7 +24,7 @@ const MenuWrapper = styled.div`
 
 const MenuLinkCard = styled.div`
   transform: ${(props) =>
-    props.menuIsOpen ? 'translateX(0)' : 'translateX(50%)'};
+    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
   transition: transform ${(props) => (props.index + 1) * 0.3}s;
   border-radius: 25px 0 0 25px;
   width: 100%;

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -15,7 +15,7 @@ const MenuWrapper = styled.div`
   transition: transform 0.3s;
 
   transform: ${(props) =>
-    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
+    props.menuIsOpen ? 'translateX(0)' : 'translateX(50%)'};
 
   @media (max-width: 768px) {
     width: 100%;
@@ -24,7 +24,7 @@ const MenuWrapper = styled.div`
 
 const MenuLinkCard = styled.div`
   transform: ${(props) =>
-    props.menuIsOpen ? 'translateX(0)' : 'translateX(100%)'};
+    props.menuIsOpen ? 'translateX(0)' : 'translateX(50%)'};
   transition: transform ${(props) => (props.index + 1) * 0.3}s;
   border-radius: 25px 0 0 25px;
   width: 100%;

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -58,7 +58,7 @@ function Menu(props) {
         key={item.title}
         menuIsOpen={props.menuIsOpen}
         backgroundColor={item.color}
-        index={index}
+        slideInDelay={(index + 1) * 0.3}
       >
         <MenuLink to={item.link}>{item.title}</MenuLink>
       </MenuLinkCard>

--- a/client/src/components/Menu.js
+++ b/client/src/components/Menu.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 const MenuWrapper = styled.div`
-  position: absolute;
+  position: fixed;
   height: 100vh;
   width: 25%;
   display: flex;

--- a/client/src/components/MenuIcon.js
+++ b/client/src/components/MenuIcon.js
@@ -36,6 +36,7 @@ const MenuIconWrapper = styled.div`
   justify-content: space-between;
   cursor: pointer;
   z-index: 2000;
+  ${(props) => (props.menuIsOpen ? 'position: fixed;right: 15px;' : '')}
 `;
 
 function MenuIcon(props) {

--- a/client/src/components/MenuIcon.js
+++ b/client/src/components/MenuIcon.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const MenuBar = styled.div`
+  width: 40px;
+  height: 3px;
+  background-color: ${(props) => props.theme.colors.altTwo};
+  transition: 1s;
+`;
+
+const MenuBarOne = styled(MenuBar)`
+  ${(props) =>
+    props.menuIsActive
+      ? 'transform: rotate(-45deg) translate(-19px, 7px);width: 56.6px;'
+      : ''}
+`;
+
+const MenuBarTwo = styled(MenuBar)`
+  ${(props) => (props.menuIsActive ? 'opacity: 0;' : '')}
+`;
+
+const MenuBarThree = styled(MenuBar)`
+  ${(props) =>
+    props.menuIsActive
+      ? 'transform: rotate(45deg) translate(-19px, -7px);width: 56.6px;'
+      : ''}
+`;
+
+const MenuIconWrapper = styled.div`
+  width: 40px;
+  height: 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+function MenuIcon() {
+  const [menuIsActive, setMenuIsActive] = React.useState(false);
+
+  function handleMenuIconWrapperClick() {
+    setMenuIsActive(!menuIsActive);
+  }
+
+  return (
+    <MenuIconWrapper
+      onClick={handleMenuIconWrapperClick}
+      menuIsActive={menuIsActive}
+    >
+      <MenuBarOne menuIsActive={menuIsActive} />
+      <MenuBarTwo menuIsActive={menuIsActive} />
+      <MenuBarThree menuIsActive={menuIsActive} />
+    </MenuIconWrapper>
+  );
+}
+
+export default MenuIcon;

--- a/client/src/components/MenuIcon.js
+++ b/client/src/components/MenuIcon.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
 const MenuBar = styled.div`
@@ -10,19 +11,20 @@ const MenuBar = styled.div`
 
 const MenuBarOne = styled(MenuBar)`
   ${(props) =>
-    props.menuIsActive
-      ? 'transform: rotate(-45deg) translate(-19px, 7px);width: 56.6px;'
+    props.menuIsOpen
+      ? 'transform: rotate(45deg) translate(7px, 19px);width: 56.6px;'
       : ''}
 `;
 
 const MenuBarTwo = styled(MenuBar)`
-  ${(props) => (props.menuIsActive ? 'opacity: 0;' : '')}
+  ${(props) =>
+    props.menuIsOpen ? 'transform: translate(-19px, 0px);opacity: 0;' : ''}
 `;
 
 const MenuBarThree = styled(MenuBar)`
   ${(props) =>
-    props.menuIsActive
-      ? 'transform: rotate(45deg) translate(-19px, -7px);width: 56.6px;'
+    props.menuIsOpen
+      ? 'transform: rotate(-45deg) translate(7px, -19px);width: 56.6px;'
       : ''}
 `;
 
@@ -33,25 +35,25 @@ const MenuIconWrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   cursor: pointer;
+  z-index: 2000;
 `;
 
-function MenuIcon() {
-  const [menuIsActive, setMenuIsActive] = React.useState(false);
-
-  function handleMenuIconWrapperClick() {
-    setMenuIsActive(!menuIsActive);
-  }
-
+function MenuIcon(props) {
   return (
     <MenuIconWrapper
-      onClick={handleMenuIconWrapperClick}
-      menuIsActive={menuIsActive}
+      onClick={props.onMenuIconClick}
+      menuIsOpen={props.menuIsOpen}
     >
-      <MenuBarOne menuIsActive={menuIsActive} />
-      <MenuBarTwo menuIsActive={menuIsActive} />
-      <MenuBarThree menuIsActive={menuIsActive} />
+      <MenuBarOne menuIsOpen={props.menuIsOpen} />
+      <MenuBarTwo menuIsOpen={props.menuIsOpen} />
+      <MenuBarThree menuIsOpen={props.menuIsOpen} />
     </MenuIconWrapper>
   );
 }
+
+MenuIcon.propTypes = {
+  menuIsOpen: PropTypes.bool,
+  onMenuIconClick: PropTypes.func,
+};
 
 export default MenuIcon;

--- a/client/src/components/MenuIcon.js
+++ b/client/src/components/MenuIcon.js
@@ -5,7 +5,7 @@ const MenuBar = styled.div`
   width: 40px;
   height: 3px;
   background-color: ${(props) => props.theme.colors.altTwo};
-  transition: 1s;
+  transition: 0.5s;
 `;
 
 const MenuBarOne = styled(MenuBar)`
@@ -32,6 +32,7 @@ const MenuIconWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  cursor: pointer;
 `;
 
 function MenuIcon() {

--- a/client/src/components/NoteContainer.js
+++ b/client/src/components/NoteContainer.js
@@ -5,7 +5,7 @@ const NoteContainer = styled.div`
   flex-direction: column;
   width: 100%;
   max-width: 600px;
-  min-height: 390px;
+  min-height: 290px;
 `;
 
 export default NoteContainer;

--- a/client/src/components/NoteContent.js
+++ b/client/src/components/NoteContent.js
@@ -3,7 +3,7 @@ import noteBaseStyles from './noteBaseStyles';
 
 const NoteContent = styled.textarea`
   ${noteBaseStyles};
-  font-size: 24px;
+  font-size: 18px;
   color: ${(props) => props.theme.colors.primary};
   margin: 6px 0;
   flex-grow: 2;

--- a/client/src/components/NoteContentReadOnly.js
+++ b/client/src/components/NoteContentReadOnly.js
@@ -7,7 +7,7 @@ import { CSSTransitionGroup } from 'react-transition-group';
 
 const NoteContentTextFromAudio = styled.div`
   ${noteBaseStyles};
-  font-size: 24px;
+  font-size: 18px;
   color: ${(props) => props.theme.colors.primary};
   margin-bottom: 12.5px;
   flex-grow: 2;
@@ -17,7 +17,7 @@ const NoteContentTextFromAudio = styled.div`
   content: "${(props) => props.placeholder}";
   }
   overflow: hidden;
-  height: 283px;
+  height: 190px;
 `;
 
 const FadeoutText = styled.div`
@@ -39,7 +39,7 @@ function NoteContentReadOnly(props) {
   React.useEffect(() => {
     // Scroll to bottom of noteContent div when new text appears
     scrollReference.current.scrollTop = scrollReference.current.scrollHeight;
-    scrollReference.current.scrollHeight > 290
+    scrollReference.current.scrollHeight > 190
       ? setShowFadeoutText(true)
       : setShowFadeoutText(false);
   }, [props.noteContent.recognizedText]);

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -52,10 +52,10 @@ function HighlightedText({ text, searchQuery }) {
   if (!text) {
     return null;
   }
- 
-   // Split text on searchQuery term, include term itself into parts, ignore case
+
+  // Split text on searchQuery term, include term itself into parts, ignore case
   const parts = text.split(new RegExp(`(${searchQuery})`, 'gi'));
-  
+
   return (
     <span>
       {parts.map((part, index) =>
@@ -72,15 +72,6 @@ function HighlightedText({ text, searchQuery }) {
 function NoteListView(props) {
   const history = useHistory();
 
-  const noteTitleHighlighted = getHighlightedText(
-    props.title,
-    props.searchQuery
-  );
-  const noteContentHighlighted = getHighlightedText(
-    props.content,
-    props.searchQuery
-  );
-
   function handleNoteListViewClick(noteId) {
     history.push(`/note/${noteId}`);
   }
@@ -88,10 +79,17 @@ function NoteListView(props) {
   return (
     <NoteCardListView onClick={() => handleNoteListViewClick(props.noteId)}>
       {props.noteHasTitle && (
-        <NoteTitleListView>{noteTitleHighlighted}</NoteTitleListView>
+        <NoteTitleListView>
+          <HighlightedText text={props.title} searchQuery={props.searchQuery} />
+        </NoteTitleListView>
       )}
       {props.noteHasContent && (
-        <NoteContentListView>{noteContentHighlighted}</NoteContentListView>
+        <NoteContentListView>
+          <HighlightedText
+            text={props.content}
+            searchQuery={props.searchQuery}
+          />
+        </NoteContentListView>
       )}
     </NoteCardListView>
   );
@@ -103,6 +101,12 @@ NoteListView.propTypes = {
   noteHasContent: PropTypes.bool,
   title: PropTypes.string,
   content: PropTypes.string,
+  text: PropTypes.string,
+  searchQuery: PropTypes.string,
+};
+
+HighlightedText.propTypes = {
+  text: PropTypes.string,
   searchQuery: PropTypes.string,
 };
 

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -48,22 +48,25 @@ const Highlighted = styled.span`
   border-radius: 5px;
 `;
 
-function getHighlightedText(text, searchQuery) {
-  if (text) {
-    // Split text on searchQuery term, include term itself into parts, ignore case
-    const parts = text.split(new RegExp(`(${searchQuery})`, 'gi'));
-    return (
-      <span>
-        {parts.map((part, index) =>
-          part.toLowerCase() === searchQuery.toLowerCase() ? (
-            <Highlighted key={index}>{part}</Highlighted>
-          ) : (
-            part
-          )
-        )}
-      </span>
-    );
+function HighlightedText({ text, searchQuery }) {
+  if (!text) {
+    return null;
   }
+ 
+   // Split text on searchQuery term, include term itself into parts, ignore case
+  const parts = text.split(new RegExp(`(${searchQuery})`, 'gi'));
+  
+  return (
+    <span>
+      {parts.map((part, index) =>
+        part.toLowerCase() === searchQuery.toLowerCase() ? (
+          <Highlighted key={index}>{part}</Highlighted>
+        ) : (
+          part
+        )
+      )}
+    </span>
+  );
 }
 
 function NoteListView(props) {

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -42,8 +42,41 @@ const NoteContentListView = styled.p`
   margin: 0;
 `;
 
+const Highlighted = styled.span`
+  background-color: #a29cb38a;
+  transition: 0.3s;
+  border-radius: 5px;
+`;
+
+function getHighlightedText(text, searchQuery) {
+  if (text) {
+    // Split text on searchQuery term, include term itself into parts, ignore case
+    const parts = text.split(new RegExp(`(${searchQuery})`, 'gi'));
+    return (
+      <span>
+        {parts.map((part, index) =>
+          part.toLowerCase() === searchQuery.toLowerCase() ? (
+            <Highlighted key={index}>{part}</Highlighted>
+          ) : (
+            part
+          )
+        )}
+      </span>
+    );
+  }
+}
+
 function NoteListView(props) {
   const history = useHistory();
+
+  const noteTitleHighlighted = getHighlightedText(
+    props.title,
+    props.searchQuery
+  );
+  const noteContentHighlighted = getHighlightedText(
+    props.content,
+    props.searchQuery
+  );
 
   function handleNoteListViewClick(noteId) {
     history.push(`/note/${noteId}`);
@@ -52,12 +85,10 @@ function NoteListView(props) {
   return (
     <NoteCardListView onClick={() => handleNoteListViewClick(props.noteId)}>
       {props.noteHasTitle && (
-        <NoteTitleListView>{props.title}</NoteTitleListView>
+        <NoteTitleListView>{noteTitleHighlighted}</NoteTitleListView>
       )}
       {props.noteHasContent && (
-        <NoteContentListView>
-          {props.content.substring(0, 250)}
-        </NoteContentListView>
+        <NoteContentListView>{noteContentHighlighted}</NoteContentListView>
       )}
     </NoteCardListView>
   );
@@ -69,6 +100,7 @@ NoteListView.propTypes = {
   noteHasContent: PropTypes.bool,
   title: PropTypes.string,
   content: PropTypes.string,
+  searchQuery: PropTypes.string,
 };
 
 export default NoteListView;

--- a/client/src/components/NoteListView.js
+++ b/client/src/components/NoteListView.js
@@ -101,7 +101,6 @@ NoteListView.propTypes = {
   noteHasContent: PropTypes.bool,
   title: PropTypes.string,
   content: PropTypes.string,
-  text: PropTypes.string,
   searchQuery: PropTypes.string,
 };
 

--- a/client/src/components/NoteTitle.js
+++ b/client/src/components/NoteTitle.js
@@ -3,7 +3,7 @@ import noteBaseStyles from './noteBaseStyles';
 
 const NoteTitle = styled.input`
   ${noteBaseStyles};
-  font-size: 30px;
+  font-size: 20px;
   font-weight: bold;
   color: ${(props) => props.theme.colors.secondary};
   margin: 6px 0;

--- a/client/src/components/NotesList.js
+++ b/client/src/components/NotesList.js
@@ -16,6 +16,7 @@ function NotesList(props) {
       return (
         <NoteListView
           key={note._id}
+          searchQuery={props.searchQuery}
           noteId={note._id}
           noteHasTitle={noteHasTitle}
           noteHasContent={noteHasContent}
@@ -31,6 +32,7 @@ function NotesList(props) {
 
 NotesList.propTypes = {
   notes: PropTypes.array,
+  searchQuery: PropTypes.string,
 };
 
 export default NotesList;

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -20,6 +20,7 @@ const SearchField = styled.input`
   border-bottom: 2px solid ${(props) => props.theme.colors.light};
   border-radius: 0px;
   transition: 0.3s;
+  z-index: -1;
 
   &:hover,
   &:focus {

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
 import { ReactComponent as SearchIcon } from '../assets/lens.svg';
+import { throttle } from 'throttle-debounce';
 import noteBaseStyles from '../components/noteBaseStyles.js';
 
 const SearchBarWrapper = styled.div`
@@ -31,11 +32,31 @@ const SearchField = styled.input`
   }
 `;
 
+const sendSearchQuery = (searchQuery) => {
+  console.log(searchQuery);
+};
+
 function SearchBar() {
+  const [searchQuery, setSearchQuery] = React.useState('');
+
+  const throttledSearchQuery = useCallback(
+    throttle(500, (searchQuery) => sendSearchQuery(searchQuery)),
+    []
+  );
+
+  function handleSearchFieldChange(event) {
+    setSearchQuery(event.target.value);
+    throttledSearchQuery(event.target.value);
+  }
+
   return (
     <SearchBarWrapper>
       <SearchIcon />
-      <SearchField placeholder="Search..." />
+      <SearchField
+        placeholder="Search..."
+        onChange={handleSearchFieldChange}
+        value={searchQuery}
+      />
     </SearchBarWrapper>
   );
 }

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -20,7 +20,6 @@ const SearchField = styled.input`
   border-bottom: 2px solid ${(props) => props.theme.colors.light};
   border-radius: 0px;
   transition: 0.3s;
-  z-index: -1;
 
   &:hover,
   &:focus {

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { ReactComponent as SearchIcon } from '../assets/lens.svg';
+import noteBaseStyles from '../components/noteBaseStyles.js';
+
+const SearchBarWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 600px;
+  padding: 1rem;
+`;
+
+const SearchField = styled.input`
+  ${noteBaseStyles}
+  width: 100%;
+  font-size: 20px;
+  margin-left: 10px;
+  color: ${(props) => props.theme.colors.primary};
+  border-bottom: 2px solid ${(props) => props.theme.colors.light};
+  border-radius: 0px;
+  transition: 0.3s;
+
+  &:hover,
+  &:focus {
+    border-bottom: 2px solid ${(props) => props.theme.colors.primary};
+  }
+
+  &::placeholder {
+    color: ${(props) => props.theme.colors.altTwo};
+    opacity: 0.4;
+  }
+`;
+
+function SearchBar() {
+  return (
+    <SearchBarWrapper>
+      <SearchIcon />
+      <SearchField placeholder="Search..." />
+    </SearchBarWrapper>
+  );
+}
+
+export default SearchBar;

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -1,7 +1,7 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
 import { ReactComponent as SearchIcon } from '../assets/lens.svg';
-import { throttle } from 'throttle-debounce';
 import noteBaseStyles from '../components/noteBaseStyles.js';
 
 const SearchBarWrapper = styled.div`
@@ -32,33 +32,22 @@ const SearchField = styled.input`
   }
 `;
 
-const sendSearchQuery = (searchQuery) => {
-  console.log(searchQuery);
-};
-
-function SearchBar() {
-  const [searchQuery, setSearchQuery] = React.useState('');
-
-  const throttledSearchQuery = useCallback(
-    throttle(500, (searchQuery) => sendSearchQuery(searchQuery)),
-    []
-  );
-
-  function handleSearchFieldChange(event) {
-    setSearchQuery(event.target.value);
-    throttledSearchQuery(event.target.value);
-  }
-
+function SearchBar(props) {
   return (
     <SearchBarWrapper>
       <SearchIcon />
       <SearchField
         placeholder="Search..."
-        onChange={handleSearchFieldChange}
-        value={searchQuery}
+        onChange={props.onSearchBarChange}
+        value={props.searchQuery}
       />
     </SearchBarWrapper>
   );
 }
+
+SearchBar.propTypes = {
+  searchQuery: PropTypes.string,
+  onSearchBarChange: PropTypes.func,
+};
 
 export default SearchBar;

--- a/client/src/components/noteBaseStyles.js
+++ b/client/src/components/noteBaseStyles.js
@@ -8,7 +8,7 @@ const noteBaseStyles = (props) => css`
   outline: none;
   resize: none;
   border-radius: 5px;
-  padding: 1rem;
+  padding: 10px;
   width: 100%;
   max-width: 600px;
   transition: 0.3s;

--- a/client/src/pages/Note.js
+++ b/client/src/pages/Note.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { getNote, postNote, updateNote } from '../api/notes';
 import NoteContainer from '../components/NoteContainer';
+import BackLink from '../components/BackLink';
 import NoteTitle from '../components/NoteTitle';
 import Divider from '../components/Divider';
 import NoteContent from '../components/NoteContent';
@@ -98,6 +99,7 @@ function Notes() {
   return (
     <>
       <NoteContainer>
+        <BackLink />
         <NoteTitle
           onChange={handleNoteTitleChange}
           onBlur={saveNote}

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { getNotes } from '../api/notes';
 import Container from '../components/Container';
+import SearchBar from '../components/SearchBar.js';
 import NotesList from '../components/NotesList';
 
 function ListNotes() {
@@ -20,6 +21,7 @@ function ListNotes() {
 
   return (
     <>
+      <SearchBar />
       {notes.length > 0 ? (
         <NotesList notes={notes} />
       ) : (

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -1,19 +1,33 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { throttle } from 'throttle-debounce';
 import { getNotes } from '../api/notes';
 import Container from '../components/Container';
 import SearchBar from '../components/SearchBar.js';
 import NotesList from '../components/NotesList';
 
 function ListNotes() {
+  const [searchQuery, setSearchQuery] = React.useState('');
+  const [throttledSearchQuery, setThrottledSearchQuery] = React.useState('');
   const [notes, setNotes] = React.useState([]);
   const [isLoading, setIsLoading] = React.useState(true);
+
+  const doThrottledSearchQueryCallback = useCallback(
+    throttle(500, (searchQuery) => setThrottledSearchQuery(searchQuery)),
+    []
+  );
+
+  function handleSearchFieldChange(event) {
+    setSearchQuery(event.target.value);
+    doThrottledSearchQueryCallback(event.target.value);
+  }
+
   React.useEffect(() => {
-    // Get all notes
-    getNotes('').then((notes) => {
+    // Get queried notes
+    getNotes(throttledSearchQuery).then((notes) => {
       setNotes(notes);
       setIsLoading(false);
     });
-  }, []);
+  }, [throttledSearchQuery]);
 
   if (isLoading) {
     return <Container>Loading...</Container>;
@@ -21,7 +35,10 @@ function ListNotes() {
 
   return (
     <>
-      <SearchBar />
+      <SearchBar
+        onSearchBarChange={handleSearchFieldChange}
+        searchQuery={searchQuery}
+      />
       {notes.length > 0 ? (
         <NotesList notes={notes} />
       ) : (

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { throttle } from 'throttle-debounce';
 import { getNotes } from '../api/notes';
 import Container from '../components/Container';
+import { ReactComponent as Loading } from '../assets/loading.svg';
 import SearchBar from '../components/SearchBar.js';
 import NotesList from '../components/NotesList';
 
@@ -18,20 +19,19 @@ function ListNotes() {
 
   function handleSearchFieldChange(event) {
     setSearchQuery(event.target.value);
-    doThrottledSearchQueryCallback(event.target.value);
+    if (event.target.value.length > 2) {
+      doThrottledSearchQueryCallback(event.target.value);
+    }
   }
 
   React.useEffect(() => {
     // Get queried notes
+    setIsLoading(true);
     getNotes(throttledSearchQuery).then((notes) => {
       setNotes(notes);
       setIsLoading(false);
     });
   }, [throttledSearchQuery]);
-
-  if (isLoading) {
-    return <Container>Loading...</Container>;
-  }
 
   return (
     <>
@@ -39,10 +39,14 @@ function ListNotes() {
         onSearchBarChange={handleSearchFieldChange}
         searchQuery={searchQuery}
       />
-      {notes.length > 0 ? (
+      {isLoading ? (
+        <Container>
+          <Loading />
+        </Container>
+      ) : notes.length > 0 ? (
         <NotesList notes={notes} />
       ) : (
-        <Container>Go ahead and create your first note :-)</Container>
+        <Container>No search results :-(</Container>
       )}
     </>
   );

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -19,7 +19,7 @@ function ListNotes() {
 
   function handleSearchFieldChange(event) {
     setSearchQuery(event.target.value);
-    if (event.target.value.length > 2) {
+    if (event.target.value.length > 2 || event.target.value.length === 0) {
       doThrottledSearchQueryCallback(event.target.value);
     }
   }
@@ -44,7 +44,7 @@ function ListNotes() {
           <Loading />
         </Container>
       ) : notes.length > 0 ? (
-        <NotesList notes={notes} />
+        <NotesList notes={notes} searchQuery={searchQuery} />
       ) : (
         <Container>No search results :-(</Container>
       )}

--- a/client/src/pages/Notes.js
+++ b/client/src/pages/Notes.js
@@ -9,7 +9,7 @@ function ListNotes() {
   const [isLoading, setIsLoading] = React.useState(true);
   React.useEffect(() => {
     // Get all notes
-    getNotes().then((notes) => {
+    getNotes('').then((notes) => {
       setNotes(notes);
       setIsLoading(false);
     });

--- a/lib/database/database.js
+++ b/lib/database/database.js
@@ -1,5 +1,7 @@
 const { MongoClient } = require('mongodb');
 
+const collectionName = 'notes';
+
 let client = null;
 let database = null;
 async function initDatabase(url, databaseName) {
@@ -22,6 +24,13 @@ async function getCollection(collectionName) {
   return database.collection(collectionName);
 }
 
+async function createIndexes() {
+  const collection = await getCollection(collectionName);
+
+  await collection.createIndex({ title: 'text', content: 'text' });
+}
+
 exports.initDatabase = initDatabase;
 exports.closeDatabase = closeDatabase;
 exports.getCollection = getCollection;
+exports.createIndexes = createIndexes;

--- a/lib/models/notes.js
+++ b/lib/models/notes.js
@@ -13,9 +13,23 @@ async function getNote(noteId) {
   return note;
 }
 
-async function getNotes(query) {
+async function getNotes(searchQuery) {
+  const textSearchQuery = searchQuery
+    ? { $text: { $search: searchQuery } }
+    : {};
+
   const notesCollection = await getCollection(collectionName);
-  const notes = await notesCollection.find(query).toArray();
+  const notes = await notesCollection
+    .find(textSearchQuery)
+    .project({ score: { $meta: 'textScore' } })
+    .sort({ score: { $meta: 'textScore' } })
+    .toArray();
+  return notes;
+}
+
+async function getAllNotes() {
+  const notesCollection = await getCollection(collectionName);
+  const notes = await notesCollection.find().toArray();
   return notes;
 }
 
@@ -50,5 +64,6 @@ async function updateNote(note, noteId) {
 
 exports.getNote = getNote;
 exports.getNotes = getNotes;
+exports.getAllNotes = getAllNotes;
 exports.postNote = postNote;
 exports.updateNote = updateNote;

--- a/lib/models/notes.js
+++ b/lib/models/notes.js
@@ -14,9 +14,8 @@ async function getNote(noteId) {
 }
 
 async function getNotes(searchQuery) {
-  const textSearchQuery = searchQuery
-    ? { $text: { $search: searchQuery } }
-    : {};
+  const textSearchQuery =
+    searchQuery.length > 0 ? { $text: { $search: searchQuery } } : {};
 
   const notesCollection = await getCollection(collectionName);
   const notes = await notesCollection

--- a/lib/routes/notes.js
+++ b/lib/routes/notes.js
@@ -16,7 +16,8 @@ router.get('/:id', async (request, response) => {
 
 router.get('/', async (request, response) => {
   try {
-    const notes = await getNotes();
+    const searchQuery = request.query.q;
+    const notes = await getNotes(searchQuery);
     return response.json(notes);
   } catch (error) {
     console.error(error);

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const http = require('http');
 const express = require('express');
 const path = require('path');
 const notes = require('./lib/routes/notes');
-const { initDatabase } = require('./lib/database/database');
+const { initDatabase, createIndexes } = require('./lib/database/database');
 const { initSocket } = require('./src/socket');
 
 const port = process.env.PORT || 8080;
@@ -41,6 +41,9 @@ if (process.env.NODE_ENV === 'production') {
   initDatabase(process.env.DB_URL, process.env.DB_NAME).then(async () => {
     console.log(`Database ${process.env.DB_NAME} is ready`);
 
+    await createIndexes();
+    console.log('Indexes created');
+
     server.listen(port, () =>
       console.log(`Express server app listening at http://localhost:${port}`)
     );
@@ -62,6 +65,9 @@ if (process.env.NODE_ENV === 'production') {
 
   initDatabase(process.env.DB_URL, process.env.DB_NAME).then(async () => {
     console.log(`Database ${process.env.DB_NAME} is ready`);
+
+    await createIndexes();
+    console.log('Indexes created');
 
     app.listen(port, () =>
       console.log(`Express server app listening at http://localhost:${port}`)


### PR DESCRIPTION
Deployment: https://dev.deepspeech-notes.haupt.digital/

In this PR, I added a full text search using MongoDB's text search operators: https://docs.mongodb.com/manual/core/text-search-operators/

Here is what the user is now able to do:
- When the search bar is empty, all available notes are displayed.
- When more than 2 characters are entered, the list of notes get's updated. 
  - Search results are sorted using MongoDB's metascore which is some sort of "relevance" criteria. Example: go to the deployment and type in "Hallo" in the search bar. You will see that the results where "Hallo" appears more often, will be displayed on top.
- The search query is not case sensitive so it is easier to find results.

Here is how I did the setup:
- Added a search bar component + icon
- Added a 500ms throttle (via `throttle-debounce` npm module) so I do not fire fetch requests with every new character in the search bar.
- Added a new route to read the `q` parameter from the fetch url call. Example: `note` is read from  `https://dev.deepspeech-notes.haupt.digital/api/notes/?q=note`
- Added a MongoDB `find()` using `$text` and `$meta: 'textScore'` which outputs the relevance score 
- Highlight text that matches the search query with a helper function. Here is where needed some help from this stackoverflow thread: https://stackoverflow.com/questions/29652862/highlight-text-using-reactjs

This PR contains commits from #39 so if you review this, you should start with commit adda0b

Along the way, I learned that MongoDB has a lot more to offer with highlighting (https://docs.atlas.mongodb.com/reference/atlas-search/highlighting/) but I was not yet able to fully work on this topic.

![dev deepspeech-notes haupt digital_(iPhone 6_7_8) (5)](https://user-images.githubusercontent.com/27010409/81018007-df733f80-8e63-11ea-96a7-edc5b530e0c1.png)
